### PR TITLE
Added the passthrough of additional KeyboardedInput props

### DIFF
--- a/src/KeyboardedInput.js
+++ b/src/KeyboardedInput.js
@@ -49,6 +49,9 @@ class KeyboardedInput extends React.Component {
     return (
       <div>
         <input 
+          name={this.props.name}
+          className={this.props.className}
+          placeholder={this.props.placeholder}
 	  value={this.props.value} 
 	  type={this.props.type} 
 	  onFocus={this.handleFocus} 


### PR DESCRIPTION
* KeyboardedInput props of name, className, and placeholder now pass
  through to child <input>
* This enables the setting of css styles on <input>, as well as
  naming the field and providing initial placeholder for text inputs.
* In particular, KeyboardedInput may now create react-bootstrap
  compatible FormControl, with onscreen keyboard

```
    <FormGroup>
      <Col componentClass={ControlLabel} sm={2}>
        Secret1
      </Col>
      <Col sm={10}>
        <KeyboardedInput
         name="element-name"
         className="form-control"  <-- Sets the CSS class
         placeholder="Placeholder value"
```