### PR TITLE
Allow custom keyboard mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,40 @@ export default Input;
 
 ```
 
+#### Use Custom Keyboard
+
+You can pass a Nx3 sized array into `defaultKeyboard` prop to render a customize layout.
+
+**Note:** The array must be 3 rows, however the size of the row's columns is not limited.
+
+```js
+
+import React from 'react';
+import KeyboardedInput from 'react-touch-screen-keyboard';
+import 'react-touch-screen-keyboard/src/Keyboard.css';
+
+class Input extends React.Component {
+  render() {
+    const CustomMapping = [
+      ['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'],
+      ['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', '@'],
+      ['z', 'x', 'c', 'v', 'b', 'n', 'm', '.com']
+    ];
+      
+    return (
+      <KeyboardedInput
+        enabled
+        type={this.props.type}
+        value={this.props.value}
+        name={this.props.name}
+        defaultKeyboard={CustomMapping}
+      />
+    );
+  }
+}
+export default Input;
+
+```
+
 
 This library was built around https://github.com/WiaczeslawP/react-screen-keyboard 's codebase. Credit where credit's due :)

--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -89,7 +89,8 @@ export default class Keyboard extends PureComponent {
 		setTimeout(() => {
 			inputNode.focus();
 			try {
-				inputNode.setSelectionRange(selectionStart + key.length, selectionStart + key.length);
+				let offset = !isFinite(key) ? key.length : 1;
+				inputNode.setSelectionRange(selectionStart + offset, selectionStart + offset);
 			} catch (e) {}
 		}, 0);
 		this.setState({uppercase: this.isUppercase()});

--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -10,13 +10,12 @@ import BackspaceIcon from './icons/BackspaceIcon';
 import LanguageIcon from './icons/LanguageIcon';
 import ShiftIcon from './icons/ShiftIcon';
 
-
 export default class Keyboard extends PureComponent {
 	static propTypes = {
 		inputNode: PropTypes.any.isRequired,
 		onClick: PropTypes.func,
 		isFirstLetterUppercase: PropTypes.bool,
-		defaultKeyboard: PropTypes.string,
+		defaultKeyboard: PropTypes.any,
 		secondaryKeyboard: PropTypes.string,
 		hideKeyboard: PropTypes.func,
 	};
@@ -90,7 +89,7 @@ export default class Keyboard extends PureComponent {
 		setTimeout(() => {
 			inputNode.focus();
 			try {
-				inputNode.setSelectionRange(selectionStart + 1, selectionStart + 1);
+				inputNode.setSelectionRange(selectionStart + key.length, selectionStart + key.length);
 			} catch (e) {}
 		}, 0);
 		this.setState({uppercase: this.isUppercase()});
@@ -151,7 +150,9 @@ export default class Keyboard extends PureComponent {
 		} else if (this.state.currentLanguage === 'de') {
 			keysSet = GermanLayout;
 		} else if (this.state.currentLanguage === 'ru') {
-			keysSet = CyrillicLayout;
+            keysSet = CyrillicLayout;
+		} else if (this.state.currentLanguage) {
+			keysSet = this.state.currentLanguage;
 		} else {
 			keysSet = LatinLayout;
 		}


### PR DESCRIPTION
Allow custom keyboard mapping to be passed through 'defaultKeyboard' and add support for >1 length buttons, such as '.com'.

Here's a quick example

CustomLayout.js

    export default [
        ['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'],
        ['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', '@'],
        ['z', 'x', 'c', 'v', 'b', 'n', 'm', '.com']
    ];

InputField.js

    import CustomLayout from 'layouts/CustomLayout';
    
    const InputField = () => (
        <div class="field-input">
            <label>Example</label>
            <div>
                <KeyboardedInput
                    enabled
                    name="example"
                    type="input"
                    defaultKeyboard={CustomLayout}
                />
            </div>
        </div>
    );
    
    export default InputField

