### PR TITLE
Partly resolves issue #25

### DIFF
--- a/lib/KeyboardButton.js
+++ b/lib/KeyboardButton.js
@@ -48,8 +48,7 @@ var KeyboardButton = function (_PureComponent) {
         'button',
         {
           type: 'button',
-          tabIndex: '-1',
-          className: 'keyboard-button ' + this.props.classes,
+          className: 'keyboard-button ' + ' ' + (this.props.classes || ''),
           onClick: this.props.isDisabled ? null : this.handleClick,
           autoFocus: this.props.autofocus,
           disabled: this.props.isDisabled

--- a/lib/KeyboardedInput.js
+++ b/lib/KeyboardedInput.js
@@ -84,7 +84,7 @@ var KeyboardedInput = function (_React$Component) {
     value: function handleFocusLost() {
       var that = this;
       setTimeout(function () {
-        if (!document.activeElement.classList.contains('keyboard-button') && !document.activeElement.classList.contains('keyboard') && !document.activeElement.classList.contains('keyboard-row')) {
+        if (!document.activeElement.classList.contains('keyboard-button') && !document.activeElement.classList.contains('keyboard') && !document.activeElement.classList.contains('keyboard-row') && !document.activeElement.classList.contains('react-draggable-transparent-selection')) {
           that.setState(_extends({}, that.state, { showKeyboard: false }));
         }
       }, 0);

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,6 @@ var Keyboard = require('./Keyboard');
 var KeyboardButton = require('./KeyboardButton');
 var KeyboardedInput = require('./KeyboardedInput');
 
-module.exports.Keyboard = Keyboard.default || Keyboard;
 module.exports = KeyboardedInput.default || KeyboardedInput;
+module.exports.Keyboard = Keyboard.default || Keyboard;
 module.exports.KeyboardButton = KeyboardButton.default || KeyboardButton;

--- a/src/KeyboardButton.js
+++ b/src/KeyboardButton.js
@@ -30,8 +30,7 @@ export default class KeyboardButton extends PureComponent {
     return (
       <button
         type="button"
-        tabIndex="-1"
-        className={`${'keyboard-button '}${this.props.classes}`}
+        className={`${'keyboard-button '} ${this.props.classes || ''}`}
         onClick={this.props.isDisabled ? null : this.handleClick}
         autoFocus={this.props.autofocus}
         disabled={this.props.isDisabled}

--- a/src/KeyboardedInput.js
+++ b/src/KeyboardedInput.js
@@ -68,7 +68,12 @@ class KeyboardedInput extends React.Component {
   handleFocusLost() {
     const that = this;
     setTimeout(() => {
-      if (!document.activeElement.classList.contains('keyboard-button') && !document.activeElement.classList.contains('keyboard') && !document.activeElement.classList.contains('keyboard-row')) {
+      // console.error(document.activeElement.classList);
+      console.error(window.event);
+      if (!document.activeElement.classList.contains('keyboard-button')
+        && !document.activeElement.classList.contains('keyboard')
+        && !document.activeElement.classList.contains('keyboard-row')
+        && !document.activeElement.classList.contains('react-draggable-transparent-selection')) {
         that.setState({ ...that.state, showKeyboard: false });
       }
     }, 0);


### PR DESCRIPTION
## The Bug

Issue #25 is that Safari is returning the <body> in the call to `document.activeElement`. I found a psot that did say this can happen when, `When the input element is blurred and the focus is in the same tab / window it returns body.`. ([Here](https://forums.asp.net/t/1676149.aspx?document+activeElement+returns+body))

This patch fixes Safari support ONLY IF draggable feature is turned on. If its disabled the issue reverts to per-patch behavior.

So in saying that this is a PATCH not a FIX. So there is a bigger issue here, however the case can be how comman is the need Safari where is can't enable the drag feature.